### PR TITLE
Backport fixes for clang-cl

### DIFF
--- a/recipe/353.patch
+++ b/recipe/353.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake/GzSetCompilerFlags.cmake b/cmake/GzSetCompilerFlags.cmake
+index 4db772f5..f4d0aa83 100644
+--- a/cmake/GzSetCompilerFlags.cmake
++++ b/cmake/GzSetCompilerFlags.cmake
+@@ -38,9 +38,13 @@ macro(_gz_set_compiler_flags)
+     _gz_setup_apple()
+   endif()
+ 
+-  # Check if we are compiling with Clang and cache it
++  # Check if we are compiling with Clang with GNU-like flags and cache it
+   if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+-    set(CLANG true)
++    if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
++      set(CLANG false)
++    else()
++      set(CLANG true)
++    endif()
+   endif()
+ 
+   # Check if we are compiling with GCC and cache it

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,11 @@ package:
 source:
   - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ major_version }}_{{ version }}.tar.gz
     sha256: 13b058772a70eceafe2d79d251de0a23c89e13bbb0808af815aaba46ad13f9c6
+    patches:
+      - 353.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
Backport https://github.com/gazebosim/gz-cmake/pull/353 to fix some problems in https://github.com/conda-forge/gz-physics-feedstock/pull/7#issuecomment-1555872781 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
