### PR TITLE
Fix FindGzOgre2 on Windows

### DIFF
--- a/recipe/357.patch
+++ b/recipe/357.patch
@@ -1,0 +1,40 @@
+diff --git a/cmake/FindGzOGRE2.cmake b/cmake/FindGzOGRE2.cmake
+index 9cb89c8a..d420703c 100644
+--- a/cmake/FindGzOGRE2.cmake
++++ b/cmake/FindGzOGRE2.cmake
+@@ -26,7 +26,6 @@
+ # to be set before calling find_package:
+ #
+ #  GZ_OGRE2_PROJECT_NAME    Possible values: OGRE2 (default) or OGRE-Next
+-#                            (Only on UNIX, not in use for Windows)
+ #                            Specify the project name used in the packaging.
+ #                            It will impact directly in the name of the
+ #                            CMake/pkg-config modules being used.
+@@ -43,8 +42,6 @@
+ #  OGRE2_RESOURCE_PATH      Path to ogre plugins directory
+ #  GzOGRE2::GzOGRE2       Imported target for OGRE2
+ #
+-# On Windows, we assume that all the OGRE* defines are passed in manually
+-# to CMake.
+ #
+ # Supports finding the following OGRE2 components: HlmsPbs, HlmsUnlit, Overlay,
+ #  PlanarReflections
+@@ -147,7 +144,8 @@ macro(get_preprocessor_entry CONTENTS KEYWORD VARIABLE)
+   endif ()
+ endmacro()
+ 
+-if (NOT WIN32)
++find_package(PkgConfig QUIET)
++if (PkgConfig_FOUND)
+   set(PKG_CONFIG_PATH_ORIGINAL $ENV{PKG_CONFIG_PATH})
+   foreach (GZ_OGRE2_PROJECT_NAME "OGRE2" "OGRE-Next")
+     message(STATUS "Looking for OGRE using the name: ${GZ_OGRE2_PROJECT_NAME}")
+@@ -393,7 +391,7 @@ if (NOT WIN32)
+   # because gz_pkg_check_modules does not work for it.
+   include(GzPkgConfig)
+   gz_pkg_config_library_entry(GzOGRE2 OgreMain)
+-else() #WIN32
++else() #PkgConfig_FOUND
+ 
+   set(OGRE2_FOUND TRUE)
+   set(OGRE_LIBRARIES "")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,8 @@ package:
 source:
   - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ major_version }}_{{ version }}.tar.gz
     sha256: 115ca3b677efabbf8ba1428ab0a7f21c1188d59089b4864904a32a44a3afa410
-
+    patches:
+      - 357.patch
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - 357.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
Fix https://github.com/conda-forge/gz-rendering-feedstock/issues/13 by backporting https://github.com/gazebosim/gz-cmake/pull/357 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
